### PR TITLE
Fix Schema Validator

### DIFF
--- a/ocsfvalidate/generate.go
+++ b/ocsfvalidate/generate.go
@@ -62,7 +62,7 @@ func fetchSchema(className string, version string) error {
 		Host:   "schema.ocsf.io",
 		Path:   path.Join("schema", fullVersion, "classes", className),
 		RawQuery: url.Values{
-			"profiles": []string{},
+			"profiles": []string{""},
 		}.Encode(),
 	}
 


### PR DESCRIPTION
Go was omitting the profile field in the URL query since it was empty. This omission lead to the validator pulling the required fields for all profiles. Adding an empty string forces Go to populate the field in the `ux.String()` call.